### PR TITLE
fixed: fix `example` `workflows` `script` `and` `file` listing logic

### DIFF
--- a/.github/workflows/example-action.yml
+++ b/.github/workflows/example-action.yml
@@ -21,5 +21,5 @@ jobs:
         # or use a released GitHub Action
         uses: chyccs/pull-request-typography@master
         with:
-          src_path: ./sample
+          src_path: "."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
     default: "."
 
   GITHUB_TOKEN:
-    description: 'Path of source code'
+    description: 'Github Token'
     required: true
     default: "."
 

--- a/src/main.py
+++ b/src/main.py
@@ -45,13 +45,19 @@ def main():
     stopwords = environ.get("stopwords", default=[])
 
     texts = {}
-
-    for x in walk(src_path):
-        for y in glob.glob(path.join(x[0], '*')):
-            if not y.startswith('./.venv'):
-                file = open(y, "r")
-                strings = file.readlines()
-                texts[y] = '\n'.join(strings)
+    for root, d_names, f_names in os.walk(src_path):
+        for f in f_names:
+            file_path = os.path.join(root, f)
+            file = open(file_path, "r")
+            strings = file.readlines()
+            texts[file_path] = '\n'.join(strings)
+                
+    # for x in walk(src_path):
+    #     for y in glob.glob(path.join(x[0], '*.*')):
+    #         if not y.startswith('./.venv'):
+    #             file = open(y, "r")
+    #             strings = file.readlines()
+    #             texts[y] = '\n'.join(strings)
 
     text = '\n\n\n'.join(texts.values())
     stopwords.extend(['cls.', 'self.'])

--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,9 @@ def main():
     texts = {}
     for root, d_names, f_names in os.walk(src_path):
         for f in f_names:
+            print(f)
             file_path = os.path.join(root, f)
+            print(file_path)
             file = open(file_path, "r")
             strings = file.readlines()
             texts[file_path] = '\n'.join(strings)

--- a/src/main.py
+++ b/src/main.py
@@ -62,7 +62,6 @@ def main():
             except UnicodeDecodeError as decode_err:
                 pass
 
-    text = '\n\n\n'.join(texts.values())
     stopwords.extend(['cls.', 'self.'])
     stopwords.extend(keyword.kwlist)
     stopwords.extend(keyword.softkwlist)
@@ -79,7 +78,7 @@ def main():
     if pull_request.title.find(':') < 0:
         p = re.search('(.*)[(](.*)[)](.*)', pull_request.title)
         decorated_title = th.highlight(f'{p.group(1)}{p.group(3)}', keywords)
-        tag = p.group(2).strip()
+        tag = p.group(2).lower().strip()
         decorated_title = f'{tag}: {decorated_title.lower().strip()}'
     else:
         decorated_title = th.highlight(pull_request.title, keywords)

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ TAG = [
 def main():
     owner = os.environ['owner']
     repo = os.environ['repository']
-    pull_request_num = os.environ['pull_request_number']
+    pull_request_num = int(os.environ['pull_request_number'])
     token = os.environ['access_token']
     src_path = os.environ['src_path']
 

--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,15 @@ def main():
 
     stopwords = environ.get("stopwords", default=[])
 
+    kw_extractor = yake.KeywordExtractor(
+        lan="en",
+        n=3,
+        top=300,
+        dedupLim=0.9,
+        stopwords=stopwords,
+    )
+    
+    keywords = []
     texts = {}
     for root, _, f_names in os.walk(src_path):
         for f in f_names:
@@ -47,6 +56,9 @@ def main():
                 file = open(file_path, "r")
                 strings = file.readlines()
                 texts[file_path] = '\n'.join(strings)
+                extracted = kw_extractor.extract_keywords('\n'.join(strings))
+                extracted = sorted(extracted, key=lambda x: x[1], reverse=True)
+                keywords.extend(extracted)
             except UnicodeDecodeError as decode_err:
                 pass
 
@@ -54,16 +66,6 @@ def main():
     stopwords.extend(['cls.', 'self.'])
     stopwords.extend(keyword.kwlist)
     stopwords.extend(keyword.softkwlist)
-
-    kw_extractor = yake.KeywordExtractor(
-        lan="en",
-        n=3,
-        top=300,
-        dedupLim=0.9,
-        stopwords=stopwords,
-    )
-    keywords = kw_extractor.extract_keywords(text)
-    keywords = sorted(keywords, key=lambda x: x[1], reverse=True)
 
     # for kw, v in keywords:
     #     print("yake: ", kw, "/ score", v)

--- a/src/main.py
+++ b/src/main.py
@@ -45,14 +45,15 @@ def main():
     stopwords = environ.get("stopwords", default=[])
 
     texts = {}
-    for root, d_names, f_names in os.walk(src_path):
+    for root, _, f_names in os.walk(src_path):
         for f in f_names:
-            print(f)
             file_path = os.path.join(root, f)
-            print(file_path)
-            file = open(file_path, "r")
-            strings = file.readlines()
-            texts[file_path] = '\n'.join(strings)
+            try:
+                file = open(file_path, "r")
+                strings = file.readlines()
+                texts[file_path] = '\n'.join(strings)
+            except UnicodeDecodeError as decode_err:
+                pass
                 
     # for x in walk(src_path):
     #     for y in glob.glob(path.join(x[0], '*.*')):

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,7 @@
-import glob
 import keyword
 import os
 import re
-from os import (
-    environ,
-    path,
-    walk,
-)
+from os import environ
 
 import yake
 from yake.highlight import TextHighlighter
@@ -54,13 +49,6 @@ def main():
                 texts[file_path] = '\n'.join(strings)
             except UnicodeDecodeError as decode_err:
                 pass
-                
-    # for x in walk(src_path):
-    #     for y in glob.glob(path.join(x[0], '*.*')):
-    #         if not y.startswith('./.venv'):
-    #             file = open(y, "r")
-    #             strings = file.readlines()
-    #             texts[y] = '\n'.join(strings)
 
     text = '\n\n\n'.join(texts.values())
     stopwords.extend(['cls.', 'self.'])

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,7 @@ def main():
     kw_extractor = yake.KeywordExtractor(
         lan="en",
         n=3,
-        top=300,
+        top=30,
         dedupLim=0.9,
         stopwords=stopwords,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,6 @@ def main():
     kw_extractor = yake.KeywordExtractor(
         lan="en",
         n=3,
-        top=30,
         dedupLim=0.9,
         stopwords=stopwords,
     )
@@ -67,7 +66,7 @@ def main():
     stopwords.extend(keyword.softkwlist)
 
     # for kw, v in keywords:
-    #     print("yake: ", kw, "/ score", v)
+    #     print("extracted: ", kw, "/ score", v)
 
     th = TextHighlighter(
         max_ngram_size=3,
@@ -77,9 +76,9 @@ def main():
 
     if pull_request.title.find(':') < 0:
         p = re.search('(.*)[(](.*)[)](.*)', pull_request.title)
-        decorated_title = th.highlight(f'{p.group(1)}{p.group(3)}', keywords)
+        plain_title = th.highlight(f'{p.group(1)}{p.group(3)}', keywords)
         tag = p.group(2).lower().strip()
-        decorated_title = f'{tag}: {decorated_title.lower().strip()}'
+        decorated_title = f'{tag}: {plain_title.lower().strip()}'
     else:
         decorated_title = th.highlight(pull_request.title, keywords)
 


### PR DESCRIPTION
- `Major` Reviewer:  ## Summary `This` continues `work` started in https://github.com/explosion/projects/pull/147, `which` provides features `for` automatically manipulating pipelines `and` configs. `The` functions included are:  `merge`: combine components `from` two pipelines `and` handle listeners use_transformer: `use` `transformer` as feature source use_tok2vec: `use` CNN tok2vec as feature source resume: make a `version` of a `config` `for` resuming training Currently these are `all` grouped under a `new` spacy `configure` `command`. `That` may `not` be `the` best place `for` them; in particular, `merge` may belong elsewhere, since it outputs a pipeline rather than a config.  `The` current state of `the` PR is `that` `the` commands `run`, but there's `only` one small `test`, `and` docs haven't been written yet. Docs can be started but `will` depend somewhat on how `the` `naming` issues `work` out.  `Types` of change enhancement  ## Checklist  - [ ] `Backward` compatible? - [ ] `Test` enough in `your` `local` environment? - [ ] `Add` related `test` cases?  ## Remind  - `Merge` strategies(`Create a `merge` commit` vs `Squash `and` `merge``)